### PR TITLE
Adding namespace info when dumping library

### DIFF
--- a/src/il2cpp/structs/class.ts
+++ b/src/il2cpp/structs/class.ts
@@ -298,6 +298,7 @@ class Il2CppClass extends NonNullNativeStruct {
 
         return `\
 // ${this.assemblyName}
+// ${this.namespace}
 ${this.isEnum ? `enum` : this.isValueType ? `struct` : this.isInterface ? `interface` : `class`} \
 ${this.type.name}\
 ${inherited ? ` : ${inherited.map(e => e?.type.name).join(`, `)}` : ``}


### PR DESCRIPTION
The namespace info will be helpful for filtering the class when using the tracer API.