### PR TITLE
ackward  compatibility  with  frida-compile  V10.2.4.

### DIFF
--- a/src/il2cpp/perform.ts
+++ b/src/il2cpp/perform.ts
@@ -10,7 +10,7 @@ namespace Il2Cpp {
 
             let thread = Il2Cpp.currentThread;
             const isForeignThread = thread == null;
-            thread ??= Il2Cpp.domain.attach();
+            thread || (thread = Il2Cpp.domain.attach());
 
             const result = block();
 

--- a/src/utils/offset-of.ts
+++ b/src/utils/offset-of.ts
@@ -4,7 +4,7 @@ interface NativePointer {
 }
 
 NativePointer.prototype.offsetOf = function (condition, depth) {
-    depth ??= 512;
+    depth || (depth = 512);
 
     for (let i = 0; i < depth; i++) {
         if (condition(this.add(i))) {


### PR DESCRIPTION
Avoid  using  the  "??="  operator  to  ensure  backward  compatibility  with  older  versions  of  frida-compile.