### PR TITLE
Add wrapper for `System.Collections.Generic.Dictionary`

### DIFF
--- a/src/il2cpp/dictionary.ts
+++ b/src/il2cpp/dictionary.ts
@@ -32,16 +32,16 @@ namespace Il2Cpp {
         /** Gets the value by the specified key of the current dictionary. */
         get(key: K): V {
             if (!this.containsKey(key)) {
-                raise(``);
+                raise(`the given key ${key} is not in the dictionary`);
             }
-
+            
             return this.method<V>("get_Item").invoke(key);
         }
 
         /** Sets the pair of the current dictionary. */
         set(key: K, value: V) {
             if (this.containsKey(key)) {
-                warn(``);
+                warn(`the given key ${key} is already in the dictionary. It will be overwritten with the new value ${value}`);
             }
 
             this.method("set_Item").invoke(key, value);

--- a/src/il2cpp/dictionary.ts
+++ b/src/il2cpp/dictionary.ts
@@ -1,0 +1,92 @@
+namespace Il2Cpp {
+    export class Dictionary<K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Il2Cpp.Object {
+        /** Gets the pairs count of the current dictionary. */
+        get length(): number {
+            return this.method<number>("get_Count").invoke();
+        }
+
+        /** Gets all pairs of the current dictionary. */
+        get entries(): Map<K, V> {
+            const entries = new Map<K, V>();
+            const values = this.values;
+            this.keys.forEach((key, index, _) => {
+                entries.set(key, values[index]);
+            });
+            return entries;
+        }
+
+        /** Gets all keys of the current dictionary. */
+        get keys(): K[] {
+            const keys = Il2Cpp.array<K>(this.class.generics[0], this.length);
+            (this.method<Il2Cpp.Object>("get_Keys").invoke()).method("CopyTo").invoke(keys, 0);
+            return keys.elements.read(this.length);
+        }
+
+        /** Gets all values of the current dictionary. */
+        get values(): V[] {
+            const values = Il2Cpp.array<V>(this.class.generics[1], this.length);
+            (this.method<Il2Cpp.Object>("get_Values").invoke()).method("CopyTo").invoke(values, 0);
+            return values.elements.read(this.length);
+        }
+
+        /** Gets the value by the specified key of the current dictionary. */
+        get(key: K): V {
+            if (!this.containsKey(key)) {
+                raise(``);
+            }
+
+            return this.method<V>("get_Item").invoke(key);
+        }
+
+        /** Sets the pair of the current dictionary. */
+        set(key: K, value: V) {
+            if (this.containsKey(key)) {
+                warn(``);
+            }
+
+            this.method("set_Item").invoke(key, value);
+        }
+
+        /** Clears the current dictionary. */
+        clear() {
+            this.method("Clear").invoke();
+        }
+
+        /** Determines if the key is in the current dictionary. */
+        containsKey(key: K): boolean {
+            return this.method<boolean>("ContainsKey").invoke(key);
+        }
+
+        /** Determines if the value is in the current dictionary. */
+        containsValue(value: V): boolean {
+            return this.method<boolean>("ContainsValue").invoke(value);
+        }
+
+        /** Finds a key in the current dictionary and returns its index. */
+        find(key: K): number {
+            return this.method<number>("FindEntry").invoke(key);
+        }
+
+        /** */
+        toString(): string {
+            return this.isNull() ? "null" : `{${[...this.entries.entries()].map(([k, v]) => `${k}: ${v}`).join(", ")}}`;
+        }
+    }
+
+    /** Creates a new dictionary with the given elements. */
+    export function dictionary<K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends Il2Cpp.Field.Type = Il2Cpp.Field.Type>(keyClass: Il2Cpp.Class, valueClass: Il2Cpp.Class, elements?: Map<K, V>): Il2Cpp.Dictionary<K, V> {
+        const dictionary = new Il2Cpp.Dictionary<K, V>(
+            Il2Cpp.corlib.class("System.Collections.Generic.Dictionary`2")
+            .inflate(keyClass, valueClass)
+            .alloc()
+        );
+
+        if (elements) {
+            for (const [key, value] of elements) {
+                dictionary.set(key, value);
+            }
+        }
+
+        return dictionary;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,6 @@
 /// <reference path="./utils/recycle.ts">/>
 /// <reference path="./utils/unity-version.ts">/>
 
-/// <reference path="./il2cpp/api.ts">/>
-/// <reference path="./il2cpp/application.ts">/>
-/// <reference path="./il2cpp/dump.ts">/>
-/// <reference path="./il2cpp/exception-listener.ts">/>
-/// <reference path="./il2cpp/filters.ts">/>
-/// <reference path="./il2cpp/gc.ts">/>
-/// <reference path="./il2cpp/memory.ts">/>
-/// <reference path="./il2cpp/module.ts">/>
-/// <reference path="./il2cpp/perform.ts">/>
-/// <reference path="./il2cpp/tracer.ts">/>
-
 /// <reference path="./il2cpp/structs/array.ts">/>
 /// <reference path="./il2cpp/structs/assembly.ts">/>
 /// <reference path="./il2cpp/structs/class.ts">/>
@@ -38,5 +27,17 @@
 /// <reference path="./il2cpp/structs/thread.ts">/>
 /// <reference path="./il2cpp/structs/type.ts">/>
 /// <reference path="./il2cpp/structs/value-type.ts">/>
+
+/// <reference path="./il2cpp/api.ts">/>
+/// <reference path="./il2cpp/application.ts">/>
+/// <reference path="./il2cpp/dictionary.ts">/>
+/// <reference path="./il2cpp/dump.ts">/>
+/// <reference path="./il2cpp/exception-listener.ts">/>
+/// <reference path="./il2cpp/filters.ts">/>
+/// <reference path="./il2cpp/gc.ts">/>
+/// <reference path="./il2cpp/memory.ts">/>
+/// <reference path="./il2cpp/module.ts">/>
+/// <reference path="./il2cpp/perform.ts">/>
+/// <reference path="./il2cpp/tracer.ts">/>
 
 globalThis.Il2Cpp = Il2Cpp;


### PR DESCRIPTION
Hey, this little change should save you a lot of extra code. You can test it using this:
```typescript
import "frida-il2cpp-bridge";

function test() {
    const myMap = new Map<number, Il2Cpp.String>([ [1, Il2Cpp.string("a")], [2, Il2Cpp.string("b")] ]);
    const dictionary = Il2Cpp.dictionary(Il2Cpp.corlib.class("System.Int32"), Il2Cpp.corlib.class("System.String"), myMap);
    
    dictionary.set(2, Il2Cpp.string("z")); //should show warn
    dictionary.set(3, Il2Cpp.string("c"));

    console.log(dictionary.get(2)); //should be "z"
    console.log(dictionary.containsKey(4)); //should be false

    dictionary.set(4, Il2Cpp.string("d"));

    console.log(dictionary.containsValue(Il2Cpp.string("d"))); //should be true
    console.log(dictionary.length); //should be 4
    console.log(dictionary.find(3)); //should be 2
    console.log(dictionary.keys); //should be 1, 2, 3, 4
    console.log(dictionary.values); //should be "a", "z", "c", "d"
    console.log(dictionary.toString()); //should be {1: "a", ...}
    
    for (const [key, value] of dictionary.entries) {
        console.log(`${key} - ${value}`); //should be 1 - "a", ...
    }
    
    dictionary.clear();
    
    console.log(dictionary.length); //should be 0
    console.log(dictionary.get(1)); //should show err
}
//@ts-ignore
globalThis.test = test;
```
after app loaded you can call `test` in frida repl

I was able to test only on android, but i think it works on other platforms.
Note: A ctor with a size exists like in array, but is essentially useless because this class has a dynamic length. Also `find` returns -1 if it doesn't find the key.
I tried to follow your coding style so there shouldn't be much difference