### PR TITLE
Find the overload method in the parent class

### DIFF
--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -273,13 +273,21 @@ namespace Il2Cpp {
 
         /** Gets the overloaded method with the given parameter types. */
         tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.Method<U> | undefined {
-            return this.class.methods.find(method => {
-                return (
-                    method.name == this.name &&
-                    method.parameterCount == parameterTypes.length &&
-                    method.parameters.every((e, i) => e.type.name == parameterTypes[i])
-                );
-            }) as Il2Cpp.Method<U> | undefined;
+            let klass: Il2Cpp.Class | null = this.class;
+            while (klass) {
+                const method = klass.methods.find(method => {
+                    return (
+                      method.name == this.name &&
+                      method.parameterCount == parameterTypes.length &&
+                      method.parameters.every((e, i) => e.type.name == parameterTypes[i])
+                    );
+                }) as Il2Cpp.Method<U> | undefined;
+                if (method) {
+                    return method;
+                }
+                klass = klass.parent;
+            }
+            return undefined;
         }
 
         /** Gets the parameter with the given name. */


### PR DESCRIPTION
for example:
```typescript
const UTF8Encoding = Il2Cpp.corlib.class('System.Text.Encoding')
  .method<Il2Cpp.Object>('get_UTF8').invoke();
const data = Il2Cpp.string('Hello world');
console.log(
  UTF8Encoding.method<Il2Cpp.Array<number>>('GetBytes')
    .overload('System.String').invoke(data),
);
// before commit: couldn't find overloaded method GetBytes(System.String)
// after commit: [72,101,108,108,111,32,119,111,114,108,100]
```