### PR TITLE
Fix tracer return value parse error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/frida-gum": "^18.4.3",
-    "ts-patch": "^3.0.2",
+    "ts-patch": "^3.2.1",
     "ts-transformer-inline-file": "^0.2.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/frida-gum": "^18.4.3",
-    "ts-patch": "^3.2.1",
+    "ts-patch": "^3.0.2",
     "ts-transformer-inline-file": "^0.2.0"
   },
   "overrides": {

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -297,15 +297,17 @@ namespace Il2Cpp {
                     state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = \x1b[31m${fromFridaValue(args[e.position + startIndex], e.type)}\x1b[0m`).join(", ")})`);
                 }
 
-                let returnValue = NULL;
+                let returnValue = method.returnType.isPrimitive ? 0 : NULL;
+                let isError = false;
                 try {
                     returnValue = method.nativeFunction(...args);
+                } catch (_) {
+                    isError = true;
                 }
-                catch (e: any) {}
 
                 if ((this as InvocationContext).threadId == threadId) {
                     // prettier-ignore
-                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m`);
+                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m${isError ? " \x1b[38;5;9m[native IL2CPP exception occurred]\x1b[0m" : ""}`);
                     state.flush();
                 }
 

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -297,7 +297,11 @@ namespace Il2Cpp {
                     state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = \x1b[31m${fromFridaValue(args[e.position + startIndex], e.type)}\x1b[0m`).join(", ")})`);
                 }
 
-                const returnValue = method.nativeFunction(...args);
+                let returnValue = NULL;
+                try {
+                    returnValue = method.nativeFunction(...args);
+                }
+                catch (e: any) {}
 
                 if ((this as InvocationContext).threadId == threadId) {
                     // prettier-ignore

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -288,34 +288,35 @@ namespace Il2Cpp {
 
             const startIndex = +!method.isStatic | +Il2Cpp.unityVersionIsBelow201830;
 
-            const fromFridaValueNullable = (args: InvocationArguments, parameter: Il2Cpp.Parameter) => {
-                try {
-                    return `\x1b[31m${fromFridaValue(args[parameter.position + startIndex], parameter.type)}\x1b[0m`;
-                } catch (_) {
-                    return null;
+            const callback = function (this: CallbackContext | InvocationContext, ...args: any[]) {
+                if ((this as InvocationContext).threadId == threadId) {
+                    const thisParameter = method.isStatic ? undefined : new Il2Cpp.Parameter("this", -1, method.class.type);
+                    const parameters = thisParameter ? [thisParameter].concat(method.parameters) : method.parameters;
+
+                    // prettier-ignore
+                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = \x1b[31m${fromFridaValue(args[e.position + startIndex], e.type)}\x1b[0m`).join(", ")})`);
                 }
+
+                let returnValue = method.returnType.isPrimitive ? 0 : NULL;
+                let isError = false;
+                try {
+                    returnValue = method.nativeFunction(...args);
+                } catch (_) {
+                    isError = true;
+                }
+
+                if ((this as InvocationContext).threadId == threadId) {
+                    // prettier-ignore
+                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m${isError ? " \x1b[38;5;9m[native IL2CPP exception occurred]\x1b[0m" : ""}`);
+                    state.flush();
+                }
+
+                return returnValue;
             };
 
             method.revert();
-
-            Interceptor.attach(method.virtualAddress, {
-                onEnter(args) {
-                    if (this.threadId == threadId) {
-                        const thisParameter = method.isStatic ? undefined : new Il2Cpp.Parameter("this", -1, method.class.type);
-                        const parameters = thisParameter ? [thisParameter].concat(method.parameters) : method.parameters;
-
-                        // prettier-ignore
-                        state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = ${fromFridaValueNullable(args, e) ?? "\x1b[38;5;9mnull (failed to parse parameter value)\x1b[0m"}`).join(", ")})`);
-                    }
-                },
-                onLeave(returnValue) {
-                    if (this.threadId == threadId) {
-                        // prettier-ignore
-                        state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m${returnValue.isNull() && method.returnType.typeEnum != Il2Cpp.Type.enum.void ? " \x1b[38;5;9m[native IL2CPP exception occurred]\x1b[0m" : ""}`);
-                        state.flush();
-                    }
-                }
-            });
+            const nativeCallback = new NativeCallback(callback, method.returnType.fridaAlias, method.fridaSignature);
+            Interceptor.replace(method.virtualAddress, nativeCallback);
         };
 
         return new Il2Cpp.Tracer(parameters ? applierWithParameters() : applier());

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -288,35 +288,34 @@ namespace Il2Cpp {
 
             const startIndex = +!method.isStatic | +Il2Cpp.unityVersionIsBelow201830;
 
-            const callback = function (this: CallbackContext | InvocationContext, ...args: any[]) {
-                if ((this as InvocationContext).threadId == threadId) {
-                    const thisParameter = method.isStatic ? undefined : new Il2Cpp.Parameter("this", -1, method.class.type);
-                    const parameters = thisParameter ? [thisParameter].concat(method.parameters) : method.parameters;
-
-                    // prettier-ignore
-                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = \x1b[31m${fromFridaValue(args[e.position + startIndex], e.type)}\x1b[0m`).join(", ")})`);
-                }
-
-                let returnValue = method.returnType.isPrimitive ? 0 : NULL;
-                let isError = false;
+            const fromFridaValueNullable = (args: InvocationArguments, parameter: Il2Cpp.Parameter) => {
                 try {
-                    returnValue = method.nativeFunction(...args);
+                    return `\x1b[31m${fromFridaValue(args[parameter.position + startIndex], parameter.type)}\x1b[0m`;
                 } catch (_) {
-                    isError = true;
+                    return null;
                 }
-
-                if ((this as InvocationContext).threadId == threadId) {
-                    // prettier-ignore
-                    state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m${isError ? " \x1b[38;5;9m[native IL2CPP exception occurred]\x1b[0m" : ""}`);
-                    state.flush();
-                }
-
-                return returnValue;
             };
 
             method.revert();
-            const nativeCallback = new NativeCallback(callback, method.returnType.fridaAlias, method.fridaSignature);
-            Interceptor.replace(method.virtualAddress, nativeCallback);
+
+            Interceptor.attach(method.virtualAddress, {
+                onEnter(args) {
+                    if (this.threadId == threadId) {
+                        const thisParameter = method.isStatic ? undefined : new Il2Cpp.Parameter("this", -1, method.class.type);
+                        const parameters = thisParameter ? [thisParameter].concat(method.parameters) : method.parameters;
+
+                        // prettier-ignore
+                        state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(state.depth++)}┌─\x1b[35m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m(${parameters.map(e => `\x1b[32m${e.name}\x1b[0m = ${fromFridaValueNullable(args, e) ?? "\x1b[38;5;9mnull (failed to parse parameter value)\x1b[0m"}`).join(", ")})`);
+                    }
+                },
+                onLeave(returnValue) {
+                    if (this.threadId == threadId) {
+                        // prettier-ignore
+                        state.buffer.push(`\x1b[2m0x${paddedVirtualAddress}\x1b[0m ${`│ `.repeat(--state.depth)}└─\x1b[33m${method.class.type.name}::\x1b[1m${method.name}\x1b[0m\x1b[0m${returnValue == undefined ? "" : ` = \x1b[36m${fromFridaValue(returnValue, method.returnType)}`}\x1b[0m${returnValue.isNull() && method.returnType.typeEnum != Il2Cpp.Type.enum.void ? " \x1b[38;5;9m[native IL2CPP exception occurred]\x1b[0m" : ""}`);
+                        state.flush();
+                    }
+                }
+            });
         };
 
         return new Il2Cpp.Tracer(parameters ? applierWithParameters() : applier());


### PR DESCRIPTION
When a method definition does not include an null value (example: `MyClass getMyClass();`) but something went wrong (or null check was stripped by il2cpp compiler) it can return `NULL` so `Error: abort was called` will be thrown (I think because `NativeFunction` expected `pointer` return type but got null)
One more note, "real" IL2CPP code checks if the value is null (at least ghidra decompiler shows that), so nothing bad should happen

Before:
```
il2cpp: 
0x00d42bc0 ┌─MyClass::.ctor(this =  (MyClass))
0x00d42bc0 └─MyClass::.ctor

Error: abort was called
    at callback (/home/commonuserlol/index.js:1316)
```

After:
```
il2cpp: 
0x00d42bc0 ┌─MyClass::.ctor(this =  (MyClass))
0x00d42bc0 └─MyClass::.ctor

il2cpp: 
0x00d41af4 ┌─MyClass::OnEnable(this = SOME_VIEW(Clone) (MyClass))
0x00d41e48 │ ┌─MyClass::GetNextReward(this = SOME_VIEW(Clone) (MyClass))
0x00d41e48 │ └─MyClass::GetNextReward = null
0x00d422c8 │ ┌─MyClass::ParseReward(this = SOME_VIEW(Clone) (MyClass), reward = null)
0x00d421f0 │ │ ┌─MyClass::OnOkButton(this = null)
0x00d421f0 │ │ └─MyClass::OnOkButton
0x00d422c8 │ └─MyClass::ParseReward
0x00d41af4 └─MyClass::OnEnable
```