### PR TITLE
Dump CS as package tree

### DIFF
--- a/src/dump.ts
+++ b/src/dump.ts
@@ -64,16 +64,16 @@ namespace Il2Cpp {
     }
 
     export function dumpTree(path?: string, ignoreAlreadyExistingDirectory: boolean = false): void {
-        const basePath = path ?? `${Il2Cpp.application.dataPath!}/${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}`;
+        path = path ?? `${Il2Cpp.application.dataPath!}/${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}`;
 
-        if (!ignoreAlreadyExistingDirectory && directoryExists(basePath)) {
-            raise(`directory ${basePath} already exists - pass ignoreAlreadyExistingDirectory = true to skip this check`);
+        if (!ignoreAlreadyExistingDirectory && directoryExists(path)) {
+            raise(`directory ${path} already exists - pass ignoreAlreadyExistingDirectory = true to skip this check`);
         }
 
         for (const assembly of Il2Cpp.domain.assemblies) {
             inform(`dumping ${assembly.name}...`);
 
-            const destination = `${basePath}/${assembly.name.replaceAll(".", "/")}.cs`;
+            const destination = `${path}/${assembly.name.replaceAll(".", "/")}.cs`;
 
             createDirectoryRecursively(destination.substring(0, destination.lastIndexOf("/")));
 
@@ -87,7 +87,7 @@ namespace Il2Cpp {
             file.close();            
         }
 
-        ok(`dump saved to ${basePath}`);
+        ok(`dump saved to ${path}`);
     }
 
     function directoryExists(path: string): boolean {

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -74,12 +74,10 @@ namespace Il2Cpp {
         }
 
         for (const assembly of Il2Cpp.domain.assemblies) {
-            const assemblyPath = assembly.name.replaceAll(".", "/") + ".cs";
-            const destination = `${basePath}/${assemblyPath}`;
-            
-            inform(`dumping ${assemblyPath}`);
+            inform(`dumping ${assembly.name}...`);
 
-            // Create directory (recursively) if necessary
+            const destination = `${basePath}/${assembly.name.replaceAll(".", "/")}.cs`;
+
             createDirectoryRecursively(destination.substring(0, destination.lastIndexOf("/")));
 
             const file = new File(destination, "w");

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -91,8 +91,8 @@ namespace Il2Cpp {
         ok(`dump saved to ${basePath}`);
     }
 
-    function directoryExists(path: string) {
-        Il2Cpp.corlib.class("System.IO.Directory").method<boolean>("Exists").invoke(Il2Cpp.string(path));
+    function directoryExists(path: string): boolean {
+        return Il2Cpp.corlib.class("System.IO.Directory").method<boolean>("Exists").invoke(Il2Cpp.string(path));
     }
 
     function createDirectoryRecursively(path: string) {

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -93,6 +93,10 @@ namespace Il2Cpp {
         ok(`dump saved to ${basePath}`);
     }
 
+    function directoryExists(path: string) {
+        Il2Cpp.corlib.class("System.IO.Directory").method<boolean>("Exists").invoke(Il2Cpp.string(path));
+    }
+
     function createDirectoryRecursively(path: string) {
         return Il2Cpp.corlib.class("System.IO.Directory").method("CreateDirectory").invoke(Il2Cpp.string(path));
     }

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -64,13 +64,11 @@ namespace Il2Cpp {
         ok(`dump saved to ${destination}`);
     }
 
-    export function dumpTree(path?: string): void {
+    export function dumpTree(path?: string, ignoreAlreadyExistingDirectory: boolean = false): void {
         const basePath = path ?? `${Il2Cpp.application.dataPath!}/${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}`;
-        const basePathExists = Il2Cpp.corlib.class("System.IO.Directory").method<boolean>("Exists").invoke(Il2Cpp.string(basePath));
 
-        if (basePathExists) {
-            warn(`directory ${basePath} already exists, skipping...`);
-            return;
+        if (!ignoreAlreadyExistingDirectory && directoryExists(basePath)) {
+            raise(`directory ${basePath} already exists - pass ignoreAlreadyExistingDirectory = true to skip this check`);
         }
 
         for (const assembly of Il2Cpp.domain.assemblies) {

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -100,7 +100,7 @@ namespace Il2Cpp {
         ok(`dump saved to ${basePath}`);
     }
 
-    function createDirectoryRecursively(p: string) {
-        return Il2Cpp.corlib.class("System.IO.Directory").method("CreateDirectory").invoke(Il2Cpp.string(p));
+    function createDirectoryRecursively(path: string) {
+        return Il2Cpp.corlib.class("System.IO.Directory").method("CreateDirectory").invoke(Il2Cpp.string(path));
     }
 }

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -63,6 +63,19 @@ namespace Il2Cpp {
         ok(`dump saved to ${destination}`);
     }
 
+    /**
+     * Just like {@link Il2Cpp.dump}, but a `.cs` file per assembly is
+     * generated instead of having a single big `.cs` file. For instance, all
+     * classes within `System.Core` and `System.Runtime.CompilerServices.Unsafe`
+     * are dumped into `System/Core.cs` and
+     * `System/Runtime/CompilerServices/Unsafe.cs`, respectively.
+     * 
+     * ```ts
+     * Il2Cpp.perform(() => {
+     *     Il2Cpp.dumpTree();
+     * });
+     * ```
+     */
     export function dumpTree(path?: string, ignoreAlreadyExistingDirectory: boolean = false): void {
         path = path ?? `${Il2Cpp.application.dataPath!}/${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}`;
 

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -108,6 +108,6 @@ namespace Il2Cpp {
     }
 
     function createDirectoryRecursively(path: string) {
-        return Il2Cpp.corlib.class("System.IO.Directory").method("CreateDirectory").invoke(Il2Cpp.string(path));
+        Il2Cpp.corlib.class("System.IO.Directory").method("CreateDirectory").invoke(Il2Cpp.string(path));
     }
 }

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -45,7 +45,6 @@ namespace Il2Cpp {
         fileName = fileName ?? `${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}.cs`;
         path = path ?? Il2Cpp.application.dataPath!;
 
-        // Create directory (recursively) if necessary
         createDirectoryRecursively(path);
 
         const destination = `${path}/${fileName}`;

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -74,7 +74,7 @@ namespace Il2Cpp {
         }
 
         for (const assembly of Il2Cpp.domain.assemblies) {
-            const assemblyPath = assembly.name.replace(".", "/") + ".cs";
+            const assemblyPath = assembly.name.replaceAll(".", "/") + ".cs";
             const destination = `${basePath}/${assemblyPath}`;
             
             inform(`dumping ${assemblyPath}`);

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -64,17 +64,12 @@ namespace Il2Cpp {
         ok(`dump saved to ${destination}`);
     }
 
-    export function dumpTree(path?: string, deleteIfExists: boolean = false): void {
+    export function dumpTree(path?: string): void {
         const basePath = path ?? `${Il2Cpp.application.dataPath!}/${Il2Cpp.application.identifier ?? "unknown"}_${Il2Cpp.application.version ?? "unknown"}`;
         const basePathExists = Il2Cpp.corlib.class("System.IO.Directory").method<boolean>("Exists").invoke(Il2Cpp.string(basePath));
 
-        if (!deleteIfExists && basePathExists) {
+        if (basePathExists) {
             warn(`directory ${basePath} already exists, skipping...`);
-            return;
-        }
-
-        if (deleteIfExists && basePathExists) {
-            warn(`directory ${basePath} already exists, but tree deletion not yet supported, skipping...`);
             return;
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,16 @@
 {
-  "compilerOptions": {
-    "target": "es2022",
-    "lib": [ "es2020" ],
-    "moduleResolution": "node",
-    "outDir": "dist",
-    "outFile": "dist/index.js",
-    "sourceRoot": ".",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "strict": true,
-    "stripInternal": true,
-    "plugins": [ 
-      { "transform": "ts-transformer-inline-file/transformer" }
-    ],
-  }
+    "compilerOptions": {
+        "target": "es2022",
+        "lib": ["es2021"],
+        "moduleResolution": "node",
+        "outDir": "dist",
+        "outFile": "dist/index.js",
+        "sourceRoot": ".",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "sourceMap": true,
+        "strict": true,
+        "stripInternal": true,
+        "plugins": [{ "transform": "ts-transformer-inline-file/transformer" }]
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,18 @@
 {
-    "compilerOptions": {
-        "target": "es2022",
-        "lib": ["es2021"],
-        "moduleResolution": "node",
-        "outDir": "dist",
-        "outFile": "dist/index.js",
-        "sourceRoot": ".",
-        "declaration": true,
-        "experimentalDecorators": true,
-        "sourceMap": true,
-        "strict": true,
-        "stripInternal": true,
-        "plugins": [{ "transform": "ts-transformer-inline-file/transformer" }]
-    }
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2021"],
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "outFile": "dist/index.js",
+    "sourceRoot": ".",
+    "declaration": true,
+    "experimentalDecorators": true,
+    "sourceMap": true,
+    "strict": true,
+    "stripInternal": true,
+    "plugins": [ 
+      { "transform": "ts-transformer-inline-file/transformer" }
+    ],
+  }
 }


### PR DESCRIPTION
Changed dump to act more like [Il2CppDumper](https://github.com/Perfare/Il2CppDumper), dumping all classes as a file tree as opposed to one massive `.cs` file. Resulting a tree like

```
./UnityEngine.cs
./UnityEngine/UIModule.cs
./UnityEngine/PhysicsModule.cs
./UnityEngine/ScreenCaptureModule.cs
./UnityEngine/AssetBundleModule.cs
...
```

→ one file per assembly.

Currently only implemented for Android (making use of its `mkdir -p` like API), but happy to implement cross-platform if there is interest in merging this.

Also, if there's interest, happy to make this backward compatible by either adding a new function with current behaviour or an opt-in parameter.