### PR TITLE
Additional interceptors: onEnter + onLeave

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -23,8 +23,12 @@ namespace Il2Cpp {
         return Il2Cpp.exports.free(pointer);
     }
 
-    /** @internal */
-    export function read(pointer: NativePointer, type: Il2Cpp.Type): Il2Cpp.Field.Type {
+    /**
+     * @param dereference If a pointer, dereference before reading? Usually `true`, but `false` for parameters for example.
+     */
+    export function read(pointer: NativePointer, type: Il2Cpp.Type, derefPointer: boolean=true): Il2Cpp.Field.Type {
+        const dereferenced = derefPointer ? pointer.readPointer() : pointer;
+
         switch (type.typeEnum) {
             case Il2Cpp.Type.enum.boolean:
                 return !!pointer.readS8();
@@ -52,27 +56,27 @@ namespace Il2Cpp {
                 return pointer.readDouble();
             case Il2Cpp.Type.enum.nativePointer:
             case Il2Cpp.Type.enum.unsignedNativePointer:
-                return pointer.readPointer();
+                return dereferenced;
             case Il2Cpp.Type.enum.pointer:
-                return new Il2Cpp.Pointer(pointer.readPointer(), type.class.baseType!);
+                return new Il2Cpp.Pointer(dereferenced, type.class.baseType!);
             case Il2Cpp.Type.enum.valueType:
+                // Never needs dereferencing
                 return new Il2Cpp.ValueType(pointer, type);
             case Il2Cpp.Type.enum.object:
             case Il2Cpp.Type.enum.class:
-                return new Il2Cpp.Object(pointer.readPointer());
+                return new Il2Cpp.Object(dereferenced);
             case Il2Cpp.Type.enum.genericInstance:
-                return type.class.isValueType ? new Il2Cpp.ValueType(pointer, type) : new Il2Cpp.Object(pointer.readPointer());
+                return type.class.isValueType ? new Il2Cpp.ValueType(pointer, type) : new Il2Cpp.Object(dereferenced);
             case Il2Cpp.Type.enum.string:
-                return new Il2Cpp.String(pointer.readPointer());
+                return new Il2Cpp.String(dereferenced);
             case Il2Cpp.Type.enum.array:
             case Il2Cpp.Type.enum.multidimensionalArray:
-                return new Il2Cpp.Array(pointer.readPointer());
+                return new Il2Cpp.Array(dereferenced);
         }
 
         raise(`couldn't read the value from ${pointer} using an unhandled or unknown type ${type.name} (${type.typeEnum}), please file an issue`);
     }
 
-    /** @internal */
     export function write(pointer: NativePointer, value: any, type: Il2Cpp.Type): NativePointer {
         switch (type.typeEnum) {
             case Il2Cpp.Type.enum.boolean:

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -4,8 +4,6 @@ namespace Il2Cpp {
     type OnLeaveCallback<T extends Il2Cpp.Method.ReturnType> = (this: Il2Cpp.Class | Il2Cpp.Object | Il2Cpp.ValueType, retval: T) => T | void;
 
     export class Method<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends NativeStruct {
-
-
         /** Gets the class in which this method is defined. */
         @lazy
         get class(): Il2Cpp.Class {
@@ -236,7 +234,6 @@ namespace Il2Cpp {
             return this.invokeRaw(NULL, ...parameters);
         }
 
-        /** @internal */
         invokeRaw(instance: NativePointerValue, ...parameters: Il2Cpp.Parameter.Type[]): T {
             const allocatedParameters = parameters.map(toFridaValue);
 
@@ -396,7 +393,7 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
                     : new Il2Cpp.Object(args[0] as NativePointer);
                 // As opposed to `Interceptor.replace`, `Interceptor.attach` doesn't
                 // interpret pointers, so use `read` instead of `fromFridaValue`
-                const parameters = this.parameters.map((_, i) => read(args[i + startIndex], _.type));
+                const parameters = this.parameters.map((_, i) => read(args[i + startIndex], _.type, false));
                 block.call(thisObject, ...parameters);
             }
         }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -18,6 +18,8 @@ namespace Il2Cpp {
                 unsignedInt: _("System.UInt32"),
                 long: _("System.Int64"),
                 unsignedLong: _("System.UInt64"),
+
+                
                 nativePointer: _("System.IntPtr"),
                 unsignedNativePointer: _("System.UIntPtr"),
                 float: _("System.Single"),


### PR DESCRIPTION
This isn't quite ready, but I wanted to start the conversation.

`onEnter` and `onLeave` (after Frida's own) are a bit less heavy-handed than replacing the whole implementation, and don't require explicit calls to the original method if you don't want to change output values. They're useful for inspection.

It's now possible to do something like
```typescript
Il2Cpp.corlib.class('System.String').method('Concat', 1).onEnter = (strings) => {
  console.log(strings);
}

Il2Cpp.corlib.class('System.String').method('Concat', 1).onLeave = (retval) => {
  return Il2Cpp.string('new return value');
}
```

However, one of my real reasons for writing them is that `set implementation` appears to break some methods. There are some types and values for which the sequence of `fromFridaValue -> toFridaValue` isn't idempotent, and breaks. I'll send a separate PR once I've fully figured out what's happening, but for now this PR helps me debug.

I'll leave some comments inline. Also, I'm super not precious about what this API should look and feel like.