### PR TITLE
Fixed Unity download for 2017+

### DIFF
--- a/unity/2017.4.40f1/Makefile
+++ b/unity/2017.4.40f1/Makefile
@@ -1,6 +1,7 @@
+UNITY_CHANGESET := 6e14067f8a9a
+
 include ../common.mk
 
-UNITY_CHANGESET := 6e14067f8a9a
 UNITY_LINKER := $(MONO) $(IL2CPP_DIR)/build/UnityLinker.exe
 IL2CPP := $(MONO) $(IL2CPP_DIR)/build/il2cpp.exe
 

--- a/unity/2018.3.0f1/Makefile
+++ b/unity/2018.3.0f1/Makefile
@@ -1,6 +1,7 @@
+UNITY_CHANGESET := 6e9a27477296
+
 include ../common.mk
 
-UNITY_CHANGESET := 6e9a27477296
 UNITY_LINKER := $(MONO) $(IL2CPP_DIR)/build/UnityLinker.exe
 IL2CPP := $(MONO) $(IL2CPP_DIR)/build/il2cpp.exe
 

--- a/unity/2019.3.0f1/Makefile
+++ b/unity/2019.3.0f1/Makefile
@@ -1,6 +1,7 @@
+UNITY_CHANGESET := ffacea4b84e7
+
 include ../common.mk
 
-UNITY_CHANGESET := ffacea4b84e7
 UNITY_LINKER := $(MONO) $(IL2CPP_DIR)/build/deploy/net471/UnityLinker.exe
 IL2CPP := $(MONO) $(IL2CPP_DIR)/build/deploy/net471/il2cpp.exe
 

--- a/unity/2021.2.0f1/Makefile
+++ b/unity/2021.2.0f1/Makefile
@@ -1,6 +1,7 @@
+UNITY_CHANGESET := 4bf1ec4b23c9
+
 include ../common.mk
 
-UNITY_CHANGESET := 4bf1ec4b23c9
 UNITY_LINKER := $(MAYBE_STRACE) $(IL2CPP_DIR)/build/deploy/UnityLinker
 IL2CPP := $(MAYBE_STRACE) $(IL2CPP_DIR)/build/deploy/il2cpp
 

--- a/unity/common.mk
+++ b/unity/common.mk
@@ -54,7 +54,7 @@ $(DLL_TARGET): $(CS_SRC) $(EDITOR_DIR) $(BUILD_DIR)
 $(BUILD_DIR):
 	@ mkdir -p "$@"
 
-ifdef $(UNITY_CHANGESET)
+ifdef UNITY_CHANGESET
 $(EDITOR_DIR):
 	@ $(ECHO) downloading editor...
 	@ $(CURL) https://netstorage.unity3d.com/unity/$(UNITY_CHANGESET)/LinuxEditorInstaller/Unity.tar.xz -O


### PR DESCRIPTION
Before this fix:

```
$ make assembly
make -C "unity/2017.4.40f1/" assembly
make[1]: Entering directory '/home/ruben/frida-il2cpp-bridge-copy/unity/2017.4.40f1'
make[1]: *** No rule to make target '/home/ruben/frida-il2cpp-bridge-copy/build/2017.4.40f1/out/GameAssembly.so', needed by 'assembly'.  Stop.
```

After this fix: downloads and links different Unity versions correctly ✅

By the way, massive man of this build system. I've been wanting to set up something like this myself but it takes a fair bit of work. Really elegant. I'll adopt a bit of TDD for future PRs.