### PR TITLE
Simplified withHolder for methods and fields

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -181,7 +181,7 @@ namespace Il2Cpp {
             if (value.type.class.isEnum) {
                 return value.field<number | Int64 | UInt64>("value__").value;
             } else {
-                const _ = value.type.class.fields.filter(_ => !_.isStatic).map(_ => toFridaValue(_.withHolder(value).value));
+                const _ = value.type.class.fields.filter(_ => !_.isStatic).map(_ => toFridaValue(_.bind(value).value));
                 return _.length == 0 ? [0] : _;
             }
         } else {

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -131,7 +131,7 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         }
     }
 
-    export class HeldField<T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Field<T> {
+    export class HeldField<T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Il2Cpp.Field<T> {
         /** @internal */
         constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
             super(handle);

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -121,24 +121,20 @@ ${this.isLiteral ? ` = ${this.type.class.isEnum ? read((this.value as Il2Cpp.Val
 ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)}`}`;
         }
 
-        /** @internal */
-        withHolder(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.HeldField<T> {
+        /** Derive a BoundField for access to this field's value for `instance`. */
+        bind(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.BoundField<T> {
             if (this.isStatic) {
                 raise(`cannot access static field ${this.class.type.name}::${this.name} from an object, use a class instead`);
             }
 
-            return HeldField.from<T>(this, instance);
+            return new BoundField<T>(this.handle, instance);
         }
     }
 
-    export class HeldField<T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Il2Cpp.Field<T> {
+    export class BoundField<T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Il2Cpp.Field<T> {
         /** @internal */
         constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
             super(handle);
-        }
-
-        static from<T extends Il2Cpp.Field.Type>(field: Il2Cpp.Field<T>, instance: Il2Cpp.Object | Il2Cpp.ValueType): HeldField<T> {
-            return new HeldField(field.handle, instance);
         }
 
         get valueHandle(): NativePointer {
@@ -153,10 +149,6 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         /** Sets the value of this field. Thread static or literal values cannot be altered yet. */
         set value(value: T) {
             write(this.valueHandle, value, this.type);
-        }
-
-        detach(): Il2Cpp.Field<T> {
-            return new Field(this.handle);
         }
     }
 

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -129,11 +129,22 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
 
             const bound = new Il2Cpp.BoundField<T>(this.handle, instance);
 
-            // Copy over previously cached @lazy properties
-            globalThis.Object.assign(
-                bound,
-                globalThis.Object.create(Il2Cpp.BoundMethod.prototype, globalThis.Object.getOwnPropertyDescriptors(this)) as Il2Cpp.BoundMethod<T>
-            );
+            // Ensure this field and its bound version have a shared @lazy cache
+            if (!(this as unknown & { _propertyCache?: Record<PropertyKey, any> })._propertyCache) {
+                globalThis.Object.defineProperty(this, "_propertyCache", {
+                    value: {},
+                    configurable: false,
+                    enumerable: false,
+                    writable: true
+                });
+            }
+
+            globalThis.Object.defineProperty(bound, "_propertyCache", {
+                value: (this as unknown & { _propertyCache?: Record<PropertyKey, any> })._propertyCache,
+                configurable: false,
+                enumerable: false,
+                writable: true
+            });
 
             return bound;
         }

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -124,7 +124,7 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         /** Derive a BoundField for access to this field's value for `instance`. */
         bind(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.BoundField<T> {
             if (this.isStatic) {
-                raise(`cannot access static field ${this.class.type.name}::${this.name} from an object, use a class instead`);
+                raise(`cannot bind static field ${this.class.type.name}::${this.name} to an object`);
             }
 
             return new BoundField<T>(this.handle, instance);

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -154,6 +154,10 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         set value(value: T) {
             write(this.valueHandle, value, this.type);
         }
+
+        detach(): Il2Cpp.Field<T> {
+            return new Field(this.handle);
+        }
     }
 
     export namespace Field {

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -127,7 +127,15 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
                 raise(`cannot bind static field ${this.class.type.name}::${this.name} to an object`);
             }
 
-            return new BoundField<T>(this.handle, instance);
+            const bound = new Il2Cpp.BoundField<T>(this.handle, instance);
+
+            // Copy over previously cached @lazy properties
+            globalThis.Object.assign(
+                bound,
+                globalThis.Object.create(Il2Cpp.BoundMethod.prototype, globalThis.Object.getOwnPropertyDescriptors(this)) as Il2Cpp.BoundMethod<T>
+            );
+
+            return bound;
         }
     }
 

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -305,13 +305,13 @@ ${this.name}\
 ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toString(16).padStart(8, `0`)}`}`;
         }
 
-        /** @internal */
-        withHolder(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.HeldMethod<T> {
+        /** Derive a BoundMethod so this method can be invoked for `instance`. */
+        bind(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.BoundMethod<T> {
             if (this.isStatic) {
                 raise(`cannot access static method ${this.class.type.name}::${this.name} from an object, use a class instead`);
             }
 
-            return HeldMethod.from<T>(this, instance);
+            return new BoundMethod<T>(this.handle, instance);
         }
 
         /** @internal */
@@ -335,7 +335,7 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         }
     }
 
-    export class HeldMethod<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends Il2Cpp.Method<T> {
+    export class BoundMethod<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends Il2Cpp.Method<T> {
         /** @internal */
         constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
             super(handle);
@@ -344,8 +344,8 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         static from<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType>(
             method: Il2Cpp.Method<T>,
             instance: Il2Cpp.Object | Il2Cpp.ValueType
-        ): HeldMethod<T> {
-            return new HeldMethod(method.handle, instance);
+        ): BoundMethod<T> {
+            return new BoundMethod(method.handle, instance);
         }
 
         /** Invokes this method. */
@@ -372,22 +372,18 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         }
 
         /** Creates a generic instance of the current generic method. */
-        inflate<R extends Il2Cpp.Method.ReturnType = T>(...classes: Il2Cpp.Class[]): Il2Cpp.HeldMethod<R> {
-            return super.inflate<R>(...classes).withHolder(this.instance);
+        inflate<R extends Il2Cpp.Method.ReturnType = T>(...classes: Il2Cpp.Class[]): Il2Cpp.BoundMethod<R> {
+            return super.inflate<R>(...classes).bind(this.instance);
         }
 
         /** Gets the overloaded method with the given parameter types. */
-        overload(...parameterTypes: string[]): Il2Cpp.HeldMethod<T> {
-            return super.overload(...parameterTypes).withHolder(this.instance);
+        overload(...parameterTypes: string[]): Il2Cpp.BoundMethod<T> {
+            return super.overload(...parameterTypes).bind(this.instance);
         }
 
         /** Gets the overloaded method with the given parameter types. */
-        tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.HeldMethod<U> | undefined {
-            return super.tryOverload<U>(...parameterTypes)?.withHolder(this.instance);
-        }
-
-        detach(): Il2Cpp.Method<T> {
-            return new Il2Cpp.Method(this.handle);
+        tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.BoundMethod<U> | undefined {
+            return super.tryOverload<U>(...parameterTypes)?.bind(this.instance);
         }
     }
 

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -311,7 +311,15 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
                 raise(`cannot bind static method ${this.class.type.name}::${this.name} to an object`);
             }
 
-            return new BoundMethod<T>(this.handle, instance);
+            const bound = new Il2Cpp.BoundMethod<T>(this.handle, instance);
+
+            // Copy over previously cached @lazy properties
+            globalThis.Object.assign(
+                bound,
+                globalThis.Object.create(Il2Cpp.BoundMethod.prototype, globalThis.Object.getOwnPropertyDescriptors(this)) as Il2Cpp.BoundMethod<T>
+            );
+
+            return bound;
         }
 
         /** @internal */

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -335,7 +335,7 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         }
     }
 
-    export class HeldMethod<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends Method<T> {
+    export class HeldMethod<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends Il2Cpp.Method<T> {
         /** @internal */
         constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
             super(handle);

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -308,7 +308,7 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         /** Derive a BoundMethod so this method can be invoked for `instance`. */
         bind(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.BoundMethod<T> {
             if (this.isStatic) {
-                raise(`cannot access static method ${this.class.type.name}::${this.name} from an object, use a class instead`);
+                raise(`cannot bind static method ${this.class.type.name}::${this.name} to an object`);
             }
 
             return new BoundMethod<T>(this.handle, instance);
@@ -339,13 +339,6 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         /** @internal */
         constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
             super(handle);
-        }
-
-        static from<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType>(
-            method: Il2Cpp.Method<T>,
-            instance: Il2Cpp.Object | Il2Cpp.ValueType
-        ): BoundMethod<T> {
-            return new BoundMethod(method.handle, instance);
         }
 
         /** Invokes this method. */

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -385,6 +385,10 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.HeldMethod<U> | undefined {
             return super.tryOverload<U>(...parameterTypes)?.withHolder(this.instance);
         }
+
+        detach(): Il2Cpp.Method<T> {
+            return new Il2Cpp.Method(this.handle);
+        }
     }
 
     let maybeObjectHeaderSize = (): number => {

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -313,11 +313,22 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
 
             const bound = new Il2Cpp.BoundMethod<T>(this.handle, instance);
 
-            // Copy over previously cached @lazy properties
-            globalThis.Object.assign(
-                bound,
-                globalThis.Object.create(Il2Cpp.BoundMethod.prototype, globalThis.Object.getOwnPropertyDescriptors(this)) as Il2Cpp.BoundMethod<T>
-            );
+            // Ensure this method and its bound version have a shared @lazy cache
+            if (!(this as unknown & { _propertyCache?: Record<PropertyKey, any> })._propertyCache) {
+                globalThis.Object.defineProperty(this, "_propertyCache", {
+                    value: {},
+                    configurable: false,
+                    enumerable: false,
+                    writable: true
+                });
+            }
+
+            globalThis.Object.defineProperty(bound, "_propertyCache", {
+                value: (this as unknown & { _propertyCache?: Record<PropertyKey, any> })._propertyCache,
+                configurable: false,
+                enumerable: false,
+                writable: true
+            });
 
             return bound;
         }

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -24,12 +24,12 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.class.method<T>(name, parameterCount).withHolder(this);
         }
 
@@ -39,17 +39,17 @@ namespace Il2Cpp {
         }
 
         /** Gets the correct virtual method from the given virtual method. */
-        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.Method<T> {
+        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.HeldMethod<T> {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -24,13 +24,13 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
-            return this.class.field<T>(name).withHolder(this);
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.BoundField<T> {
+            return this.class.field<T>(name).bind(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
-            return this.class.method<T>(name, parameterCount).withHolder(this);
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.BoundMethod<T> {
+            return this.class.method<T>(name, parameterCount).bind(this);
         }
 
         /** Creates a reference to this object. */
@@ -39,18 +39,18 @@ namespace Il2Cpp {
         }
 
         /** Gets the correct virtual method from the given virtual method. */
-        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.HeldMethod<T> {
-            return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).withHolder(this);
+        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.BoundMethod<T> {
+            return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).bind(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
-            return this.class.tryField<T>(name)?.withHolder(this);
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.BoundField<T> | undefined {
+            return this.class.tryField<T>(name)?.bind(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
-            return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.BoundMethod<T> | undefined {
+            return this.class.tryMethod<T>(name, parameterCount)?.bind(this);
         }
 
         /** */

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -10,23 +10,23 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
-            return this.type.class.field<T>(name).withHolder(this);
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.BoundField<T> {
+            return this.type.class.field<T>(name).bind(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
-            return this.type.class.method<T>(name, parameterCount).withHolder(this);
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.BoundMethod<T> {
+            return this.type.class.method<T>(name, parameterCount).bind(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
-            return this.type.class.tryField<T>(name)?.withHolder(this);
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.BoundField<T> | undefined {
+            return this.type.class.tryField<T>(name)?.bind(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
-            return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.BoundMethod<T> | undefined {
+            return this.type.class.tryMethod<T>(name, parameterCount)?.bind(this);
         }
 
         /** */

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -10,22 +10,22 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.type.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.type.class.method<T>(name, parameterCount).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.type.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -6,15 +6,22 @@ function lazy(_: any, propertyKey: PropertyKey, descriptor: PropertyDescriptor) 
         throw new Error("@lazy can only be applied to getter accessors");
     }
 
-    descriptor.get = function () {
-        const value = getter.call(this);
-        Object.defineProperty(this, propertyKey, {
-            value,
-            configurable: descriptor.configurable,
-            enumerable: descriptor.enumerable,
-            writable: false
-        });
-        return value;
+    descriptor.get = function (this: unknown & { _propertyCache?: Record<PropertyKey, any> }) {
+        if (!this._propertyCache) {
+            Object.defineProperty(this, "_propertyCache", {
+                value: {},
+                configurable: false,
+                enumerable: false,
+                writable: true
+            });
+        }
+
+        if (!(propertyKey in this._propertyCache!)) {
+            this._propertyCache![propertyKey] = getter.call(this);
+        }
+
+        return this._propertyCache![propertyKey];
     };
+
     return descriptor;
 }


### PR DESCRIPTION
This is a minor refactoring PR, adding zero functionality. I've just committed soooo many reasoning mistakes because of those sneaky proxies that took me ages to debug to do something about it.

`Method`s are never attached to an object, `HeldMethod`s always are. When `invoke`d, each will behave predictably: 
- `Method` → static method call
- `HeldMethod` → class/struct instance method call

Same goes for `Field` and `HeldField`.

I'm flexible on naming, just tried to stick close to what was already there. Perhaps `AttachedMethod`?

All tests pass on a Linux.