### PR TITLE
Find methods using their signatures

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -517,6 +517,10 @@ namespace Il2Cpp {
 
         get typeGetTypeEnum() {
             return r("il2cpp_type_get_type", "int", ["pointer"]);
+        },
+
+        get typeEquals() {
+            return r("il2cpp_type_equals", "bool", ["pointer", "pointer"]);
         }
     };
 

--- a/src/structs/class.ts
+++ b/src/structs/class.ts
@@ -340,7 +340,7 @@ namespace Il2Cpp {
 
         tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.Method<T> | undefined {
             return this.methods.find(
-                m => m.name == name && m.parameters.length == paramTypes.length && m.parameters.every((p, i) => p.type.isSame(paramTypes[i]))
+                m => m.name == name && m.parameters.length == paramTypes.length && m.parameters.every((p, i) => Il2Cpp.is(p.type.class)(paramTypes[i]))
             ) as Il2Cpp.Method<T> | undefined;
         }
 

--- a/src/structs/class.ts
+++ b/src/structs/class.ts
@@ -306,6 +306,10 @@ namespace Il2Cpp {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.classGetMethodFromName(this, Memory.allocUtf8String(name), parameterCount)).asNullable();
         }
 
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.Method<T> | undefined {
+            return this.methods.find(m => m.name == name && m.parameters.every((p, i) => p.type.isSame(paramTypes[i]))) as Il2Cpp.Method<T> | undefined;
+        }
+
         /** Gets the nested class with the given name. */
         tryNested(name: string): Il2Cpp.Class | undefined {
             return this.nestedClasses.find(_ => _.name == name);

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -154,6 +154,10 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         set value(value: T) {
             write(this.valueHandle, value, this.type);
         }
+
+        detach(): Il2Cpp.Field<T> {
+            return new Field(this.handle);
+        }
     }
 
     export namespace Field {

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -385,6 +385,10 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.HeldMethod<U> | undefined {
             return super.tryOverload<U>(...parameterTypes)?.withHolder(this.instance);
         }
+
+        detach(): Il2Cpp.Method<T> {
+            return new Il2Cpp.Method(this.handle);
+        }
     }
 
     let maybeObjectHeaderSize = (): number => {

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -24,12 +24,12 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.class.method<T>(name, parameterCount).withHolder(this);
         }
 
@@ -39,17 +39,17 @@ namespace Il2Cpp {
         }
 
         /** Gets the correct virtual method from the given virtual method. */
-        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.Method<T> {
+        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.HeldMethod<T> {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -33,6 +33,10 @@ namespace Il2Cpp {
             return this.class.method<T>(name, parameterCount).withHolder(this);
         }
 
+        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
+            return this.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+
         /** Creates a reference to this object. */
         ref(pin: boolean): Il2Cpp.GCHandle {
             return new Il2Cpp.GCHandle(Il2Cpp.exports.gcHandleNew(this, +pin));
@@ -51,6 +55,10 @@ namespace Il2Cpp {
         /** Gets the field with the given name. */
         tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        }
+
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
+            return this.class.tryMethodWithSignature<T>(name, ...paramTypes)?.withHolder(this);
         }
 
         /** */

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -154,5 +154,9 @@ namespace Il2Cpp {
         toString(): string {
             return this.name;
         }
+
+        isSame(other: Il2Cpp.Type): boolean {
+            return !!Il2Cpp.exports.typeEquals(this.handle, other.handle);
+        }
     }
 }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -162,25 +162,16 @@ namespace Il2Cpp {
         static fromValue(value: Il2Cpp.Parameter.Type): Il2Cpp.Type {
             const _ = (kls: string) => Il2Cpp.corlib.class(kls).type;
 
-            if (typeof value === "boolean")
-                return _("System.Boolean");
-            if (typeof value === "number") 
-                if (Number.isInteger(value)) 
-                    return _("System.Int32");
-                else 
-                    return _("System.Double");
-            if (value instanceof Int64) 
-                return _("System.Int64");
-            if (value instanceof UInt64)
-                return _("System.UInt64");
-            if (value instanceof NativePointer)
-                return _("System.IntPtr");
-            if (value instanceof Il2Cpp.Object)
-                return value.class.type;
-            if (value instanceof Il2Cpp.String)
-                return _("System.String");
-            if (value instanceof Il2Cpp.Array)
-                return value.object.class.type;
+            if (typeof value === "boolean") return _("System.Boolean");
+            if (typeof value === "number")
+                if (Number.isInteger(value)) return _("System.Int32");
+                else return _("System.Double");
+            if (value instanceof Int64) return _("System.Int64");
+            if (value instanceof UInt64) return _("System.UInt64");
+            if (value instanceof NativePointer) return _("System.IntPtr");
+            if (value instanceof Il2Cpp.Object) return value.class.type;
+            if (value instanceof Il2Cpp.String) return _("System.String");
+            if (value instanceof Il2Cpp.Array) return value.object.class.type;
 
             return value.type;
         }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -158,5 +158,31 @@ namespace Il2Cpp {
         isSame(other: Il2Cpp.Type): boolean {
             return !!Il2Cpp.exports.typeEquals(this.handle, other.handle);
         }
+
+        static fromValue(value: Il2Cpp.Parameter.Type): Il2Cpp.Type {
+            const _ = (kls: string) => Il2Cpp.corlib.class(kls).type;
+
+            if (typeof value === "boolean")
+                return _("System.Boolean");
+            if (typeof value === "number") 
+                if (Number.isInteger(value)) 
+                    return _("System.Int32");
+                else 
+                    return _("System.Double");
+            if (value instanceof Int64) 
+                return _("System.Int64");
+            if (value instanceof UInt64)
+                return _("System.UInt64");
+            if (value instanceof NativePointer)
+                return _("System.IntPtr");
+            if (value instanceof Il2Cpp.Object)
+                return value.class.type;
+            if (value instanceof Il2Cpp.String)
+                return _("System.String");
+            if (value instanceof Il2Cpp.Array)
+                return value.object.class.type;
+
+            return value.type;
+        }
     }
 }

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -19,6 +19,10 @@ namespace Il2Cpp {
             return this.type.class.method<T>(name, parameterCount).withHolder(this);
         }
 
+        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+
         /** Gets the field with the given name. */
         tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.type.class.tryField<T>(name)?.withHolder(this);
@@ -27,6 +31,10 @@ namespace Il2Cpp {
         /** Gets the field with the given name. */
         tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        }
+
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
         }
 
         /** */

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -10,22 +10,22 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.type.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.type.class.method<T>(name, parameterCount).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.type.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -389,6 +389,14 @@ Il2Cpp.perform(() => {
         });
     });
 
+    test("Can look up a method with abstract types in signature" , () => {
+        assert("System.Type", () => {
+            const runtimeType = Il2Cpp.string("").object.method("GetType").invoke();
+            const method = Il2Cpp.corlib.class("System.RuntimeType").tryMethodWithSignature("MakePointerType", Il2Cpp.Type.fromValue(runtimeType));
+            return method.parameters[0].type.name;
+        });
+    });
+
     test("References to value types are created correctly", () => {
         const Decimal = Il2Cpp.corlib.class("System.Decimal").initialize();
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -295,6 +295,34 @@ Il2Cpp.perform(() => {
         assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
     });
 
+    test("Struct methods can be found using their signature", () => {
+        assert(ptr(0xdeadbeef), () => {
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().unbox();
+            runtimeTypeHandle.methodWithSignature(".ctor", Il2Cpp.corlib.class("System.IntPtr").type).invoke(ptr(0xdeadbeef));
+            return runtimeTypeHandle.method("get_Value").invoke();
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
+    test("Struct constructors with parameters can be invoked via `new`", () => {
+        assert(ptr(0xdeadbeef), () => {
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").new(ptr(0xdeadbeef));
+            return runtimeTypeHandle.method("get_Value").invoke();
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
+    test("Overloaded struct methods can be found by signature", () => {
+        assert(true, () => {
+            const runtimeType = Il2Cpp.string("").object.method("GetType").invoke();
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().unbox();
+            runtimeTypeHandle.methodWithSignature(".ctor", Il2Cpp.Type.fromValue(runtimeType)).invoke(runtimeType);
+            const reconstructedRuntimeType = Il2Cpp.corlib.class("System.RuntimeType").method("GetTypeFromHandle").invoke(runtimeTypeHandle);
+            return runtimeType.method('Equals').invoke(reconstructedRuntimeType);
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
     test("Boxing/unboxing structs works correctly", () => {
         assert(ptr(0xdeadbeef), () => {
             const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc();


### PR DESCRIPTION
So far, it was only possible to find a method by parameter count. Also, `new` always called the default constructor.

It's now possible to find a method using a parameter list of type `Il2Cpp.Type`. That also means it's possible to call non-default constructors (see new tests).

The full verbose version looks like this:
```typescript
Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().unbox().methodWithSignature(".ctor", Il2Cpp.Type.fromValue(ptr(0xdeadbeef)).invoke(ptr(0xdeadbeef))
```

Or, simplified in the case of constructors because types can just be inferred:
```typescript
Il2Cpp.corlib.class("System.RuntimeTypeHandle").new(ptr(0xdeadbeef))
```

Separate PR coming to generalise this shorthand for finding methods beyond constructors.

All tests succeed. If there's interest in this PR I'll add additional tests for other types.

Small dependency on #598.