### PR TITLE
Method call shorthand

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -517,6 +517,10 @@ namespace Il2Cpp {
 
         get typeGetTypeEnum() {
             return r("il2cpp_type_get_type", "int", ["pointer"]);
+        },
+
+        get typeEquals() {
+            return r("il2cpp_type_equals", "bool", ["pointer", "pointer"]);
         }
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@
 /// <reference path="./perform.ts">/>
 /// <reference path="./tracer.ts">/>
 
+/// <reference path="./structs/common/object-like.ts">/>
+/// <reference path="./structs/common/dynamic-methods.ts">/>
 /// <reference path="./structs/array.ts">/>
 /// <reference path="./structs/assembly.ts">/>
 /// <reference path="./structs/class.ts">/>
@@ -32,7 +34,6 @@
 /// <reference path="./structs/image.ts">/>
 /// <reference path="./structs/memory-snapshot.ts">/>
 /// <reference path="./structs/method.ts">/>
-/// <reference path="./structs/object-like.ts">/>
 /// <reference path="./structs/object.ts">/>
 /// <reference path="./structs/parameter.ts">/>
 /// <reference path="./structs/pointer.ts">/>

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@
 /// <reference path="./structs/image.ts">/>
 /// <reference path="./structs/memory-snapshot.ts">/>
 /// <reference path="./structs/method.ts">/>
+/// <reference path="./structs/object-like.ts">/>
 /// <reference path="./structs/object.ts">/>
 /// <reference path="./structs/parameter.ts">/>
 /// <reference path="./structs/pointer.ts">/>

--- a/src/structs/class.ts
+++ b/src/structs/class.ts
@@ -275,7 +275,10 @@ namespace Il2Cpp {
         }
 
         methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.Method<T> {
-            return this.tryMethodWithSignature<T>(name, ...paramTypes) ?? raise(`couldn't find method ${name} in class ${this.type.name}`);
+            return (
+                this.tryMethodWithSignature<T>(name, ...paramTypes) ??
+                raise(`couldn't find method ${name} in class ${this.type.name} for parameter types [${paramTypes.map(_ => _.name).join(", ")}]`)
+            );
         }
 
         /** Gets the nested class with the given name. */
@@ -332,6 +335,11 @@ namespace Il2Cpp {
         /** Gets the nested class with the given name. */
         tryNested(name: string): Il2Cpp.Class | undefined {
             return this.nestedClasses.find(_ => _.name == name);
+        }
+
+        @lazy
+        get m(): Il2Cpp.DynamicMethods {
+            return Il2Cpp.DynamicMethodsLookup.from(this, true);
         }
 
         /** */

--- a/src/structs/class.ts
+++ b/src/structs/class.ts
@@ -1,13 +1,4 @@
 namespace Il2Cpp {
-    interface ParameterValue {
-        type: Il2Cpp.Type;
-        value: Il2Cpp.Parameter.Type;
-    }
-
-    function isParameterValue(v: ParameterValue | Il2Cpp.Parameter.Type): v is ParameterValue {
-        return (v as ParameterValue).type !== undefined;
-    }
-
     @recycle
     export class Class extends NativeStruct {
         /** Gets the actual size of the instance of the current class. */
@@ -313,17 +304,11 @@ namespace Il2Cpp {
          * Finds the best fit constructor given the parameter types.
          * Doesn't cover constructors with default parameters – all parameters must be provided.
          */
-        new(...parameters: (ParameterValue | Il2Cpp.Parameter.Type)[]): Il2Cpp.Object {
+        new(...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]): Il2Cpp.Object {
             if (parameters.length == 0) return this.defaultNew();
 
-            const paramTypes = parameters.map(p => (isParameterValue(p) ? p.type : Il2Cpp.Type.fromValue(p)));
-            const paramValues = parameters.map(p => (isParameterValue(p) ? p.value : p));
-
-            const constructor =
-                this.tryMethodWithSignature(".ctor", ...paramTypes) ?? raise(`Couldn't find constructor with signature ${paramTypes}) in class ${this.type})`);
-
             const object = this.alloc();
-            constructor.withHolder(object).invoke(...paramValues);
+            object.m[".ctor"](...parameters);
 
             return object;
         }

--- a/src/structs/class.ts
+++ b/src/structs/class.ts
@@ -306,6 +306,10 @@ namespace Il2Cpp {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.classGetMethodFromName(this, Memory.allocUtf8String(name), parameterCount)).asNullable();
         }
 
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.Method<T> | undefined {
+            return this.methods.find(m => m.name == name && m.parameters.every((p, i) => p.type.isSame(paramTypes[i]))) as Il2Cpp.Method<T> | undefined;
+        }
+
         /** Gets the nested class with the given name. */
         tryNested(name: string): Il2Cpp.Class | undefined {
             return this.nestedClasses.find(_ => _.name == name);

--- a/src/structs/common/dynamic-methods.ts
+++ b/src/structs/common/dynamic-methods.ts
@@ -1,0 +1,34 @@
+namespace Il2Cpp {
+    export type DynamicMethods = {
+        [K in Exclude<string, ["constructor" | "#invokeMethod"]>]: (...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]) => any;
+    };
+
+    export class DynamicMethodsLookup {
+        constructor(public readonly target: Il2Cpp.ObjectLike | Il2Cpp.Class, isStatic: boolean) {
+            this.class.methods
+                .filter(m => !m.isStatic === !isStatic)
+                .forEach(m => {
+                    globalThis.Object.defineProperty(this, m.name, {
+                        value: this.#invokeMethod.bind(this, m.name),
+                        enumerable: true,
+                        configurable: true
+                    });
+                });
+        }
+
+        get class(): Il2Cpp.Class {
+            return this.target instanceof Il2Cpp.ObjectLike ? this.target.class : this.target;
+        }
+
+        #invokeMethod<T extends Il2Cpp.Method.ReturnType>(name: string, ...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]): T {
+            const paramTypes = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.type : Il2Cpp.Type.fromValue(p)));
+            const paramValues = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.value : p));
+
+            return this.target.methodWithSignature<T>(name, ...paramTypes).invoke(...paramValues);
+        }
+
+        static from(target: Il2Cpp.ObjectLike | Il2Cpp.Class, isStatic: boolean): Il2Cpp.DynamicMethods {
+            return new DynamicMethodsLookup(target, isStatic) as unknown as Il2Cpp.DynamicMethods;
+        }
+    }
+}

--- a/src/structs/common/object-like.ts
+++ b/src/structs/common/object-like.ts
@@ -32,33 +32,8 @@ namespace Il2Cpp {
         }
 
         @lazy
-        get m(): DynamicMethods {
-            return new ObjectMethods(this) as unknown as DynamicMethods;
-        }
-    }
-
-    type DynamicMethods = {
-        [K in Exclude<string, ["constructor" | "#invokeMethod"]>]: (...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]) => any;
-    };
-
-    class ObjectMethods {
-        constructor(public readonly object: Il2Cpp.ObjectLike) {
-            this.object.class.methods
-                .filter(m => !m.isStatic)
-                .forEach(m => {
-                    globalThis.Object.defineProperty(this, m.name, {
-                        value: this.#invokeMethod.bind(this, m.name),
-                        enumerable: true,
-                        configurable: true
-                    });
-                });
-        }
-
-        #invokeMethod<T extends Il2Cpp.Method.ReturnType>(name: string, ...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]): T {
-            const paramTypes = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.type : Il2Cpp.Type.fromValue(p)));
-            const paramValues = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.value : p));
-
-            return this.object.methodWithSignature<T>(name, ...paramTypes).invoke(...paramValues);
+        get m(): Il2Cpp.DynamicMethods {
+            return Il2Cpp.DynamicMethodsLookup.from(this, false);
         }
     }
 }

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -154,6 +154,10 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         set value(value: T) {
             write(this.valueHandle, value, this.type);
         }
+
+        detach(): Il2Cpp.Field<T> {
+            return new Field(this.handle);
+        }
     }
 
     export namespace Field {

--- a/src/structs/field.ts
+++ b/src/structs/field.ts
@@ -122,7 +122,7 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
         }
 
         /** @internal */
-        withHolder(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.HeldField<T> {
+        withHolder(instance: Il2Cpp.ObjectLike): Il2Cpp.HeldField<T> {
             if (this.isStatic) {
                 raise(`cannot access static field ${this.class.type.name}::${this.name} from an object, use a class instead`);
             }
@@ -133,11 +133,11 @@ ${this.isThreadStatic || this.isLiteral ? `` : ` // 0x${this.offset.toString(16)
 
     export class HeldField<T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type> extends Field<T> {
         /** @internal */
-        constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
+        constructor(handle: NativePointerValue, public instance: Il2Cpp.ObjectLike) {
             super(handle);
         }
 
-        static from<T extends Il2Cpp.Field.Type>(field: Il2Cpp.Field<T>, instance: Il2Cpp.Object | Il2Cpp.ValueType): HeldField<T> {
+        static from<T extends Il2Cpp.Field.Type>(field: Il2Cpp.Field<T>, instance: Il2Cpp.ObjectLike): HeldField<T> {
             return new HeldField(field.handle, instance);
         }
 

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -306,7 +306,7 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         }
 
         /** @internal */
-        withHolder(instance: Il2Cpp.Object | Il2Cpp.ValueType): Il2Cpp.HeldMethod<T> {
+        withHolder(instance: Il2Cpp.ObjectLike): Il2Cpp.HeldMethod<T> {
             if (this.isStatic) {
                 raise(`cannot access static method ${this.class.type.name}::${this.name} from an object, use a class instead`);
             }
@@ -337,14 +337,11 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
 
     export class HeldMethod<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType> extends Method<T> {
         /** @internal */
-        constructor(handle: NativePointerValue, public instance: Il2Cpp.Object | Il2Cpp.ValueType) {
+        constructor(handle: NativePointerValue, public instance: Il2Cpp.ObjectLike) {
             super(handle);
         }
 
-        static from<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType>(
-            method: Il2Cpp.Method<T>,
-            instance: Il2Cpp.Object | Il2Cpp.ValueType
-        ): HeldMethod<T> {
+        static from<T extends Il2Cpp.Method.ReturnType = Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method<T>, instance: Il2Cpp.ObjectLike): HeldMethod<T> {
             return new HeldMethod(method.handle, instance);
         }
 

--- a/src/structs/method.ts
+++ b/src/structs/method.ts
@@ -385,6 +385,10 @@ ${this.virtualAddress.isNull() ? `` : ` // 0x${this.relativeVirtualAddress.toStr
         tryOverload<U extends Il2Cpp.Method.ReturnType = T>(...parameterTypes: string[]): Il2Cpp.HeldMethod<U> | undefined {
             return super.tryOverload<U>(...parameterTypes)?.withHolder(this.instance);
         }
+
+        detach(): Il2Cpp.Method<T> {
+            return new Il2Cpp.Method(this.handle);
+        }
     }
 
     let maybeObjectHeaderSize = (): number => {

--- a/src/structs/object-like.ts
+++ b/src/structs/object-like.ts
@@ -1,0 +1,34 @@
+namespace Il2Cpp {
+    export abstract class ObjectLike extends NativeStruct {
+        abstract get class(): Il2Cpp.Class;
+        abstract get type(): Il2Cpp.Type;
+
+        /** Gets the field with the given name. */
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
+            return this.type.class.field<T>(name).withHolder(this);
+        }
+
+        /** Gets the method with the given name. */
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
+            return this.type.class.method<T>(name, parameterCount).withHolder(this);
+        }
+
+        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+
+        /** Gets the field with the given name. */
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
+            return this.type.class.tryField<T>(name)?.withHolder(this);
+        }
+
+        /** Gets the field with the given name. */
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
+            return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        }
+
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+    }
+}

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -1,5 +1,5 @@
 namespace Il2Cpp {
-    export class Object extends NativeStruct {
+    export class Object extends Il2Cpp.ObjectLike {
         /** Gets the Il2CppObject struct size, possibly equal to `Process.pointerSize * 2`. */
         @lazy
         static get headerSize(): number {
@@ -10,6 +10,12 @@ namespace Il2Cpp {
         @lazy
         get class(): Il2Cpp.Class {
             return new Il2Cpp.Class(Il2Cpp.exports.objectGetClass(this));
+        }
+
+        /** Gets the type of this object. */
+        @lazy
+        get type(): Il2Cpp.Type {
+            return this.class.type;
         }
 
         @lazy
@@ -28,20 +34,6 @@ namespace Il2Cpp {
             return Il2Cpp.exports.objectGetSize(this);
         }
 
-        /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
-            return this.class.field<T>(name).withHolder(this);
-        }
-
-        /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
-            return this.class.method<T>(name, parameterCount).withHolder(this);
-        }
-
-        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
-            return this.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
-        }
-
         /** Creates a reference to this object. */
         ref(pin: boolean): Il2Cpp.GCHandle {
             return new Il2Cpp.GCHandle(Il2Cpp.exports.gcHandleNew(this, +pin));
@@ -50,20 +42,6 @@ namespace Il2Cpp {
         /** Gets the correct virtual method from the given virtual method. */
         virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.HeldMethod<T> {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).withHolder(this);
-        }
-
-        /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
-            return this.class.tryField<T>(name)?.withHolder(this);
-        }
-
-        /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
-            return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
-        }
-
-        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
-            return this.class.tryMethodWithSignature<T>(name, ...paramTypes)?.withHolder(this);
         }
 
         /** */

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -24,12 +24,12 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.class.method<T>(name, parameterCount).withHolder(this);
         }
 
@@ -39,17 +39,17 @@ namespace Il2Cpp {
         }
 
         /** Gets the correct virtual method from the given virtual method. */
-        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.Method<T> {
+        virtualMethod<T extends Il2Cpp.Method.ReturnType>(method: Il2Cpp.Method): Il2Cpp.HeldMethod<T> {
             return new Il2Cpp.Method<T>(Il2Cpp.exports.objectGetVirtualMethod(this, method)).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -18,11 +18,6 @@ namespace Il2Cpp {
             return this.class.type;
         }
 
-        @lazy
-        get m(): DynamicMethods {
-            return new ObjectMethods(this) as unknown as DynamicMethods;
-        }
-
         /** Returns a monitor for this object. */
         get monitor(): Il2Cpp.Object.Monitor {
             return new Il2Cpp.Object.Monitor(this);
@@ -59,31 +54,6 @@ namespace Il2Cpp {
         /** Creates a weak reference to this object. */
         weakRef(trackResurrection: boolean): Il2Cpp.GCHandle {
             return new Il2Cpp.GCHandle(Il2Cpp.exports.gcHandleNewWeakRef(this, +trackResurrection));
-        }
-    }
-
-    type DynamicMethods = {
-        [K in Exclude<string, ["constructor" | "#invokeMethod"]>]: (...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]) => any;
-    };
-
-    class ObjectMethods {
-        constructor(public readonly object: Il2Cpp.Object) {
-            this.object.class.methods
-                .filter(m => !m.isStatic)
-                .forEach(m => {
-                    globalThis.Object.defineProperty(this, m.name, {
-                        value: this.#invokeMethod.bind(this, m.name),
-                        enumerable: true,
-                        configurable: true
-                    });
-                });
-        }
-
-        #invokeMethod<T extends Il2Cpp.Method.ReturnType>(name: string, ...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]): T {
-            const paramTypes = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.type : Il2Cpp.Type.fromValue(p)));
-            const paramValues = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.value : p));
-
-            return this.object.methodWithSignature<T>(name, ...paramTypes).invoke(...paramValues);
         }
     }
 

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -12,6 +12,11 @@ namespace Il2Cpp {
             return new Il2Cpp.Class(Il2Cpp.exports.objectGetClass(this));
         }
 
+        @lazy
+        get m(): DynamicMethods {
+            return new ObjectMethods(this) as unknown as DynamicMethods;
+        }
+
         /** Returns a monitor for this object. */
         get monitor(): Il2Cpp.Object.Monitor {
             return new Il2Cpp.Object.Monitor(this);
@@ -76,6 +81,31 @@ namespace Il2Cpp {
         /** Creates a weak reference to this object. */
         weakRef(trackResurrection: boolean): Il2Cpp.GCHandle {
             return new Il2Cpp.GCHandle(Il2Cpp.exports.gcHandleNewWeakRef(this, +trackResurrection));
+        }
+    }
+
+    type DynamicMethods = {
+        [K in Exclude<string, ["constructor" | "#invokeMethod"]>]: (...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]) => any;
+    };
+
+    class ObjectMethods {
+        constructor(public readonly object: Il2Cpp.Object) {
+            this.object.class.methods
+                .filter(m => !m.isStatic)
+                .forEach(m => {
+                    globalThis.Object.defineProperty(this, m.name, {
+                        value: this.#invokeMethod.bind(this, m.name),
+                        enumerable: true,
+                        configurable: true
+                    });
+                });
+        }
+
+        #invokeMethod<T extends Il2Cpp.Method.ReturnType>(name: string, ...parameters: (Il2Cpp.Parameter.TypeValue | Il2Cpp.Parameter.Type)[]): T {
+            const paramTypes = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.type : Il2Cpp.Type.fromValue(p)));
+            const paramValues = parameters.map(p => (Il2Cpp.Parameter.isTypeValue(p) ? p.value : p));
+
+            return this.object.methodWithSignature<T>(name, ...paramTypes).invoke(...paramValues);
         }
     }
 

--- a/src/structs/object.ts
+++ b/src/structs/object.ts
@@ -33,6 +33,10 @@ namespace Il2Cpp {
             return this.class.method<T>(name, parameterCount).withHolder(this);
         }
 
+        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
+            return this.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+
         /** Creates a reference to this object. */
         ref(pin: boolean): Il2Cpp.GCHandle {
             return new Il2Cpp.GCHandle(Il2Cpp.exports.gcHandleNew(this, +pin));
@@ -51,6 +55,10 @@ namespace Il2Cpp {
         /** Gets the field with the given name. */
         tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        }
+
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
+            return this.class.tryMethodWithSignature<T>(name, ...paramTypes)?.withHolder(this);
         }
 
         /** */

--- a/src/structs/parameter.ts
+++ b/src/structs/parameter.ts
@@ -23,5 +23,14 @@ namespace Il2Cpp {
 
     export namespace Parameter {
         export type Type = Il2Cpp.Field.Type | Il2Cpp.Reference;
+
+        export type TypeValue = {
+            type: Il2Cpp.Type;
+            value: Type;
+        };
+
+        export function isTypeValue(v: TypeValue | Type): v is TypeValue {
+            return (v as TypeValue).type !== undefined;
+        }
     }
 }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -154,5 +154,9 @@ namespace Il2Cpp {
         toString(): string {
             return this.name;
         }
+
+        isSame(other: Il2Cpp.Type): boolean {
+            return !!Il2Cpp.exports.typeEquals(this.handle, other.handle);
+        }
     }
 }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -162,25 +162,16 @@ namespace Il2Cpp {
         static fromValue(value: Il2Cpp.Parameter.Type): Il2Cpp.Type {
             const _ = (kls: string) => Il2Cpp.corlib.class(kls).type;
 
-            if (typeof value === "boolean")
-                return _("System.Boolean");
-            if (typeof value === "number") 
-                if (Number.isInteger(value)) 
-                    return _("System.Int32");
-                else 
-                    return _("System.Double");
-            if (value instanceof Int64) 
-                return _("System.Int64");
-            if (value instanceof UInt64)
-                return _("System.UInt64");
-            if (value instanceof NativePointer)
-                return _("System.IntPtr");
-            if (value instanceof Il2Cpp.Object)
-                return value.class.type;
-            if (value instanceof Il2Cpp.String)
-                return _("System.String");
-            if (value instanceof Il2Cpp.Array)
-                return value.object.class.type;
+            if (typeof value === "boolean") return _("System.Boolean");
+            if (typeof value === "number")
+                if (Number.isInteger(value)) return _("System.Int32");
+                else return _("System.Double");
+            if (value instanceof Int64) return _("System.Int64");
+            if (value instanceof UInt64) return _("System.UInt64");
+            if (value instanceof NativePointer) return _("System.IntPtr");
+            if (value instanceof Il2Cpp.Object) return value.class.type;
+            if (value instanceof Il2Cpp.String) return _("System.String");
+            if (value instanceof Il2Cpp.Array) return value.object.class.type;
 
             return value.type;
         }

--- a/src/structs/type.ts
+++ b/src/structs/type.ts
@@ -158,5 +158,31 @@ namespace Il2Cpp {
         isSame(other: Il2Cpp.Type): boolean {
             return !!Il2Cpp.exports.typeEquals(this.handle, other.handle);
         }
+
+        static fromValue(value: Il2Cpp.Parameter.Type): Il2Cpp.Type {
+            const _ = (kls: string) => Il2Cpp.corlib.class(kls).type;
+
+            if (typeof value === "boolean")
+                return _("System.Boolean");
+            if (typeof value === "number") 
+                if (Number.isInteger(value)) 
+                    return _("System.Int32");
+                else 
+                    return _("System.Double");
+            if (value instanceof Int64) 
+                return _("System.Int64");
+            if (value instanceof UInt64)
+                return _("System.UInt64");
+            if (value instanceof NativePointer)
+                return _("System.IntPtr");
+            if (value instanceof Il2Cpp.Object)
+                return value.class.type;
+            if (value instanceof Il2Cpp.String)
+                return _("System.String");
+            if (value instanceof Il2Cpp.Array)
+                return value.object.class.type;
+
+            return value.type;
+        }
     }
 }

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -19,6 +19,10 @@ namespace Il2Cpp {
             return this.type.class.method<T>(name, parameterCount).withHolder(this);
         }
 
+        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+        }
+
         /** Gets the field with the given name. */
         tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.type.class.tryField<T>(name)?.withHolder(this);
@@ -27,6 +31,10 @@ namespace Il2Cpp {
         /** Gets the field with the given name. */
         tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
+        }
+
+        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
+            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
         }
 
         /** */

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -1,40 +1,16 @@
 namespace Il2Cpp {
-    export class ValueType extends NativeStruct {
+    export class ValueType extends Il2Cpp.ObjectLike {
         constructor(handle: NativePointer, readonly type: Il2Cpp.Type) {
             super(handle);
         }
 
+        get class(): Il2Cpp.Class {
+            return this.type.class;
+        }
+
         /** Boxes the current value type in a object. */
         box(): Il2Cpp.Object {
-            return new Il2Cpp.Object(Il2Cpp.exports.valueTypeBox(this.type.class, this));
-        }
-
-        /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
-            return this.type.class.field<T>(name).withHolder(this);
-        }
-
-        /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
-            return this.type.class.method<T>(name, parameterCount).withHolder(this);
-        }
-
-        methodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> {
-            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
-        }
-
-        /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
-            return this.type.class.tryField<T>(name)?.withHolder(this);
-        }
-
-        /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
-            return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
-        }
-
-        tryMethodWithSignature<T extends Il2Cpp.Method.ReturnType>(name: string, ...paramTypes: Il2Cpp.Type[]): Il2Cpp.HeldMethod<T> | undefined {
-            return this.type.class.methodWithSignature<T>(name, ...paramTypes).withHolder(this);
+            return new Il2Cpp.Object(Il2Cpp.exports.valueTypeBox(this.class, this));
         }
 
         /** */

--- a/src/structs/value-type.ts
+++ b/src/structs/value-type.ts
@@ -10,22 +10,22 @@ namespace Il2Cpp {
         }
 
         /** Gets the field with the given name. */
-        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> {
+        field<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> {
             return this.type.class.field<T>(name).withHolder(this);
         }
 
         /** Gets the method with the given name. */
-        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> {
+        method<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> {
             return this.type.class.method<T>(name, parameterCount).withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.Field<T> | undefined {
+        tryField<T extends Il2Cpp.Field.Type>(name: string): Il2Cpp.HeldField<T> | undefined {
             return this.type.class.tryField<T>(name)?.withHolder(this);
         }
 
         /** Gets the field with the given name. */
-        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.Method<T> | undefined {
+        tryMethod<T extends Il2Cpp.Method.ReturnType>(name: string, parameterCount: number = -1): Il2Cpp.HeldMethod<T> | undefined {
             return this.type.class.tryMethod<T>(name, parameterCount)?.withHolder(this);
         }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -389,6 +389,13 @@ Il2Cpp.perform(() => {
         });
     });
 
+    test("Methods can be found and invoked by parameter type", () => {
+        assert("System.String", () => {
+            const runtimeType = Il2Cpp.string("").object.m.GetType();
+            return runtimeType.m.getFullName(true, false).content;
+        });
+    });
+
     test("References to value types are created correctly", () => {
         const Decimal = Il2Cpp.corlib.class("System.Decimal").initialize();
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -295,6 +295,34 @@ Il2Cpp.perform(() => {
         assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
     });
 
+    test("Struct methods can be found using their signature", () => {
+        assert(ptr(0xdeadbeef), () => {
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().unbox();
+            runtimeTypeHandle.methodWithSignature(".ctor", Il2Cpp.corlib.class("System.IntPtr").type).invoke(ptr(0xdeadbeef));
+            return runtimeTypeHandle.method("get_Value").invoke();
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
+    test("Struct constructors with parameters can be invoked via `new`", () => {
+        assert(ptr(0xdeadbeef), () => {
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").new(ptr(0xdeadbeef));
+            return runtimeTypeHandle.method("get_Value").invoke();
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
+    test("Overloaded struct methods can be found by signature", () => {
+        assert(true, () => {
+            const runtimeType = Il2Cpp.string("").object.method("GetType").invoke();
+            const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().unbox();
+            runtimeTypeHandle.methodWithSignature(".ctor", Il2Cpp.Type.fromValue(runtimeType)).invoke(runtimeType);
+            const reconstructedRuntimeType = Il2Cpp.corlib.class("System.RuntimeType").method("GetTypeFromHandle").invoke(runtimeTypeHandle);
+            return runtimeType.method('Equals').invoke(reconstructedRuntimeType);
+        });
+        assert("System.RuntimeTypeHandle", () => Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc().toString());
+    });
+
     test("Boxing/unboxing structs works correctly", () => {
         assert(ptr(0xdeadbeef), () => {
             const runtimeTypeHandle = Il2Cpp.corlib.class("System.RuntimeTypeHandle").alloc();


### PR DESCRIPTION
This isn't a PR (yet anyway).

Rather, a discussion. To make this fully usable for me, I added some shorthands for quick prototyping, but mainly exploration.

Before, we might have done something like
```
runtimeType.method('getFullName').invoke(true, false)
```
This would get a fair bit more complicated for overloaded methods, but let's not get into that. This draft/idea simplifies method calling:
```
runtimeType.m.getFullName(true, false)
```

First however, you'd need to know what method to call in the first place. I might try in the Frida REPL:
```
runtimeType.class.methods.map(m => m.name)
```
Now, however, this simply becomes
```
runtimeType.m.<TAB>
```
resulting in

<img width="415" alt="image" src="https://github.com/user-attachments/assets/dd946e36-74bf-419f-98ab-5f7031988a25" />

Making this a truly powerful exploratory tool. 

The topic for discussion then: does this kind of usability fit this repos scope? Or is it better suited to a layer on top, a toolkit that relies on frida-il2cpp-bridge?
