### PR TITLE
Add keywords for PackageManager discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A Frida module to dump, trace or hijack any Il2Cpp application at runtime, without needing the global-metadata.dat file.",
   "keywords": [
     "frida",
+    "frida-gum",
+    "frida-gum-bridge",
     "il2cpp",
     "dump",
     "trace",


### PR DESCRIPTION
:wave: About to introduce the `Frida.PackageManager` API, which uses npm as its backend. The idea is to streamline the process for new users so Node.js + npm aren't needed, and make it easy to discover bridges and other libraries written for frida-gum's JavaScript runtime. The goal is just the bare minimum for searching and installing packages, power-users should still be using the `npm` CLI.

The `Frida.PackageManager.search()` API will surface packages with the `frida-gum` keyword, and will also support specifying a category that it ANDs into the query, to list only bridges for example.