### PR TITLE
Resolves indefinite loop due to path condition never evaluating to true

### DIFF
--- a/cli/src/__init__.py
+++ b/cli/src/__init__.py
@@ -3,7 +3,7 @@ from os import environ
 import json
 
 
-__name__ = environ.get("npm_lifecycle_script", "frida-il2cpp-bridge")
+__name__ = environ.get("npm_lifecycle_script", "frida-il2cpp-bridge").strip('"')
 
 NPM_MODULE_PATH = Path(__file__)
 while NPM_MODULE_PATH.stem != __name__:


### PR DESCRIPTION
This is a result of npm change wrapping the command being executed in double quotes in the event its a bash keyword (e.g. select) https://github.com/npm/cli/commit/fdc3413019c2f34f1fde35449e5f3a6b0fb51ba2

Raised the following question in [NPM](https://github.com/npm/cli/issues/8542)