### PR TITLE
fix: change array retrieval method to use a special string

### DIFF
--- a/lib/structs/array.ts
+++ b/lib/structs/array.ts
@@ -11,10 +11,11 @@ namespace Il2Cpp {
             // We previosly obtained an array whose content is known by calling
             // 'System.String::Split(NULL)' on a known string. However, that
             // method invocation somehow blows things up in Unity 2018.3.0f1.
-            const array = Il2Cpp.string("v").object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
+            const SPECIAL_STRING = "26d62ea6-2f1d-4de4-8773-7a656169dccd"
+            const array = Il2Cpp.string(SPECIAL_STRING).object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
 
             // prettier-ignore
-            const offset = array.handle.offsetOf(_ => _.readS16() == 118) ??
+            const offset = array.handle.offsetOf(_ => _.readUtf16String(SPECIAL_STRING.length) == SPECIAL_STRING) ??
                 raise("couldn't find the elements offset in the native array struct");
 
             // prettier-ignore

--- a/lib/structs/array.ts
+++ b/lib/structs/array.ts
@@ -11,10 +11,10 @@ namespace Il2Cpp {
             // We previosly obtained an array whose content is known by calling
             // 'System.String::Split(NULL)' on a known string. However, that
             // method invocation somehow blows things up in Unity 2018.3.0f1.
-            const array = Il2Cpp.string("26d62ea6").object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
+            const array = Il2Cpp.string("vfsfitvnm").object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
 
             // prettier-ignore
-            const offset = Memory.scanSync(array.handle, 0xff, '32 00 36 00 64 00 36 00 32 00 65 00 61 00 36 00')[0]?.address?.sub(array.handle)
+            const offset = Memory.scanSync(array.handle, 0xff, "76 00 66 00 73 00 66 00 69 00 74 00 76 00 6e 00 6d 00")[0]?.address?.sub(array.handle)
                 ?? raise("couldn't find the elements offset in the native array struct");
 
             // prettier-ignore

--- a/lib/structs/array.ts
+++ b/lib/structs/array.ts
@@ -11,6 +11,8 @@ namespace Il2Cpp {
             // We previosly obtained an array whose content is known by calling
             // 'System.String::Split(NULL)' on a known string. However, that
             // method invocation somehow blows things up in Unity 2018.3.0f1.
+            //
+            // See https://github.com/vfsfitvnm/frida-il2cpp-bridge/pull/717
             const array = Il2Cpp.string("vfsfitvnm").object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
 
             // prettier-ignore

--- a/lib/structs/array.ts
+++ b/lib/structs/array.ts
@@ -11,12 +11,11 @@ namespace Il2Cpp {
             // We previosly obtained an array whose content is known by calling
             // 'System.String::Split(NULL)' on a known string. However, that
             // method invocation somehow blows things up in Unity 2018.3.0f1.
-            const SPECIAL_STRING = "26d62ea6-2f1d-4de4-8773-7a656169dccd"
-            const array = Il2Cpp.string(SPECIAL_STRING).object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
+            const array = Il2Cpp.string("26d62ea6").object.method<Il2Cpp.Array>("ToCharArray", 0).invoke();
 
             // prettier-ignore
-            const offset = array.handle.offsetOf(_ => _.readUtf16String(SPECIAL_STRING.length) == SPECIAL_STRING) ??
-                raise("couldn't find the elements offset in the native array struct");
+            const offset = Memory.scanSync(array.handle, 0xff, '32 00 36 00 64 00 36 00 32 00 65 00 61 00 36 00')[0]?.address?.sub(array.handle)
+                ?? raise("couldn't find the elements offset in the native array struct");
 
             // prettier-ignore
             getter(Il2Cpp.Array.prototype, "elements", function (this: Il2Cpp.Array) {


### PR DESCRIPTION
I came across an issue in some specific machine:
```
Error: access violation accessing 0xb4000076
    at get class (/script.js:2660)
    at call (native)
    at <anonymous> (/script.js:792)
    at tryMethod (/script.js:2714)
    at method (/script.js:2676)
    at toString (/script.js:2718)
    at join (native)
    at toString (native)
    at join (native)
    at sendLogMessage (/ZBgug/runtime/console.js:46)
    at log (/ZBgug/runtime/console.js:15)
    at get generics (/script.js:1592)
    at call (native)
    at <anonymous> (/script.js:792)
    at <anonymous> (/script.js:3113)
    at _ (/script.js:3084)
    at get Enum (/script.js:3113)
    at call (native)
    at <anonymous> (/script.js:792)
    at read (/script.js:952)
    at get value (/script.js:2023)
    at toString (/script.js:2042)
    at join (native)
    at toString (/script.js:1781)
    at join (native)
    at sendLogMessage (/ZBgug/runtime/console.js:46)
    at log (/ZBgug/runtime/console.js:15)
    at <eval> (/script.js:3322)
```

Through debugging, I've identified the issue: the offset for the first element is miscalculated. On the affected machines, the pointer at offset 4 sometimes exactly points to a data block whose first 4 bytes, by coincidence, read as the value 'v'. This specific coincidence tricks the library into thinking the offset is 4, not the actual 32.

We should make the feature string longer to avoid being fooled by this coincidental data alignment.

Fixes #688