### PR TITLE
Add test to check if result of methods returning big structs is corrupted due to bad handling of sret in frida 17

### DIFF
--- a/test/agent/src/index.ts
+++ b/test/agent/src/index.ts
@@ -82,8 +82,8 @@ Il2Cpp.perform(() => {
     });
 
     test("Il2Cpp.Image::classCount", () => {
-        assert(Il2Cpp.domain.assembly("GameAssembly").image.classes.length).is(33);
-        assert(Il2Cpp.domain.assembly("GameAssembly").image.classCount).is(33);
+        assert(Il2Cpp.domain.assembly("GameAssembly").image.classes.length).is(36);
+        assert(Il2Cpp.domain.assembly("GameAssembly").image.classCount).is(36);
     });
 
     test("Il2Cpp.Class::image", () => {
@@ -618,5 +618,36 @@ Il2Cpp.perform(() => {
         assert(() => Il2Cpp.nullable(null as any, Il2Cpp.corlib.class("System.Object")).type.class).throws(
             "Cannot create nullable value type out of a reference type 'System.Object'"
         );
+    });
+    // --- Struct return hook tests (Interceptor.replace via .implementation) ---
+
+    test("Hooked method returning medium struct with passthrough result", () => {
+        const SRT = Il2Cpp.domain.assembly("GameAssembly").image.class("StructReturnTest");
+        const method = SRT.method<Il2Cpp.ValueType>("GetMediumResult");
+
+        method.implementation = function (...args) {
+            return method.invoke(...args);
+        };
+
+        const result = method.invoke(3, 77);
+        assert(result.field<number>("Code").value).is(3);
+        assert(result.field<number>("Value").value).is(77);
+        SRT.method("GetMediumResult").revert();
+    });
+
+    test("Hooked method returning large struct (sret) with passthrough result", () => {
+        const SRT = Il2Cpp.domain.assembly("GameAssembly").image.class("StructReturnTest");
+        const method = SRT.method<Il2Cpp.ValueType>("GetLargeResult");
+        const msg = Il2Cpp.string("passthrough");
+        const entity = Il2Cpp.corlib.class("System.Object").new();
+
+        method.implementation = function (...args) {
+            return method.invoke(...args);
+        };
+
+        const result = method.invoke(5, msg, entity);
+        assert(result.field<number>("Reason").value).is(5);
+        assert(result.field<Il2Cpp.String>("Message").value.content).is("passthrough");
+        SRT.method("GetLargeResult").revert();
     });
 }).then(() => send({ action: "stop" }));

--- a/test/src/GameAssembly.cs
+++ b/test/src/GameAssembly.cs
@@ -355,3 +355,35 @@ class NullableTest
         return a ?? b ?? 777;
     }
 }
+
+public struct MediumStructResult
+{
+    public int Code;
+    public int Value;
+}
+
+public struct LargeStructResult
+{
+    public int Reason;
+    public string Message;
+    public object Entity;
+}
+
+public static class StructReturnTest
+{
+    public static MediumStructResult GetMediumResult(int code, int value)
+    {
+        return new MediumStructResult { Code = code, Value = value };
+    }
+
+    public static LargeStructResult GetLargeResult(int code, string message, object entity)
+    {
+        return new LargeStructResult
+        {
+            Reason = code,
+            Message = message,
+            Entity = entity
+        };
+    }
+
+}


### PR DESCRIPTION
This PR adds two tests where we hook methods that return structs.

The first test has a struct that is small enough to fit in registers when returning, the other one has a struct that needs to make use of sret.

The first struct passes fine but when SRET is used the returned struct gets corrupted and accessing its contents might lead to errors if what was corrupted was a pointer. (In our case the string pointer gets corrupted).

It seems that this only happens when using `.implementation =` hooks due to some breaking change in how NativeCallback works in frida 17. ( Using frida 16 doesn't cause this issue)

