### PR TITLE
Fix race condition when waiting for IL2CPP initialization

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -72,8 +72,10 @@ namespace Il2Cpp {
                 }, 1000);
 
                 const interceptor = Interceptor.attach(Il2Cpp.exports.initialize, {
-                    onLeave() {
+                    onEnter() {
                         clearTimeout(timeout);
+                    },
+                    onLeave() {
                         interceptor.detach();
                         blocking ? resolve(true) : setImmediate(() => resolve(false));
                     }


### PR DESCRIPTION
Commit https://github.com/vfsfitvnm/frida-il2cpp-bridge/commit/7259b853de703335896e993e56958577d8ada4a8 introduced a timeout for ``Il2Cpp.exports.initialize`` however, heavy Il2Cpp applications might block longer than 1 second to finish which causes frida-il2cpp-bridge to wrongly assume that Il2Cpp has been loaded.

This causes undefined behavior since the function is being called from the main Il2Cpp thread while the timeout is scheduled on the JS thread, which then corlib is no longer NULL as Il2Cpp is partially initialized, ``frida-il2cpp-bridge`` assumes it is loaded and proceeds on executing.
This race condition caused a deadlock in the test application with the message "resuming execution despite IL2CPP initialization not being captured in time, please open an issue as this is suboptimal".

I have moved the ``clearTimeout`` to the onEnter callback which is probably a better choice here since we assume this function is going to finish even if it blocks for a while, let me know if you have a better solution here.