### PR TITLE
Fix indefinite loop caused by path condition never evaluating to true

### DIFF
--- a/cli/src/__init__.py
+++ b/cli/src/__init__.py
@@ -3,7 +3,7 @@ from os import environ
 import json
 
 
-__name__ = environ.get("npm_lifecycle_script", "frida-il2cpp-bridge").strip('"')
+__name__ = environ.get("npm_lifecycle_script", "frida-il2cpp-bridge").strip('"\'')
 
 NPM_MODULE_PATH = Path(__file__)
 while NPM_MODULE_PATH.stem != __name__:


### PR DESCRIPTION
### Environment
* **OS:** Arch Linux
* **Python Version:** 3.14.6
* **Execution Method:** `npx frida-il2cpp-bridge`

### Problem Description
Running `frida-il2cpp-bridge` via `npx` hangs indefinitely with 100% CPU usage.

### Root Cause
In `cli/src/__init__.py`, the `while` loop condition `NPM_MODULE_PATH.stem != __name__` never evaluates to `False`. 

When invoked via `npx` in certain Linux environments, the target module name string is extracted with single quotes (e.g., `'frida-il2cpp-bridge'`). Because only double quotes were previously stripped, the directory stem (`frida-il2cpp-bridge`) never matches the quoted module name, causing the loop to traverse up to the root directory `/` indefinitely.

### Fix
Strip single quotes alongside double quotes when sanitizing the module name:

```python
__name__ = ...strip('"\'')